### PR TITLE
Display Grunt alias tasks in the Project Menu

### DIFF
--- a/GruntParser.js
+++ b/GruntParser.js
@@ -11,7 +11,11 @@ define(function(require, exports, module){
             initConfig: function(_config) {
                 config = _config;
             },
-            registerTask: noop,
+            registerTask: function(_name) {
+                if (_name !== "default") {
+                    targets.push(_name);
+                }
+            },
             registerMultiTask: noop,
             renameTask: noop,
             loadTasks: noop,

--- a/GruntParser.spec.js
+++ b/GruntParser.spec.js
@@ -56,6 +56,7 @@ define(function (require, exports, module) {
             "    grunt.loadNpmTasks('grunt-contrib-uglify');\r\n" +
             "    grunt.loadNpmTasks('grunt-typescript');\r\n" +
             "    grunt.loadNpmTasks('grunt-contrib-watch');\r\n" +
+            "    grunt.registerTask('custom', ['typescript', 'uglify']);\r\n" +
             "    grunt.registerTask('default', ['typescript', 'uglify']);\r\n" +
             "}";
         var targets = testapi.parse(text);
@@ -66,6 +67,7 @@ define(function (require, exports, module) {
             expect(targets).toContain("typescript");
             expect(targets).toContain("uglify");
             expect(targets).toContain("watch");
+            expect(targets).toContain("custom");
         });
         it("Should return sub-tasks with colon", function () {
             expect(targets).toContain("typescript:smash");


### PR DESCRIPTION
Nice extension! This is a small change to display alias tasks made through **registerTask()**.
